### PR TITLE
Fix force close on Android Pie while playing a song and make the notification permament while playing

### DIFF
--- a/src/com/android/music/MediaPlaybackService.java
+++ b/src/com/android/music/MediaPlaybackService.java
@@ -1871,6 +1871,7 @@ public class MediaPlaybackService extends Service {
             status.bigContentView = viewsLarge;
             if (isPlaying()) {
                 status.flags |= Notification.FLAG_ONGOING_EVENT;
+                status.flags |= Notification.FLAG_NO_CLEAR;
             } else {
                 status.flags = 0;
             }

--- a/src/com/android/music/MediaPlaybackService.java
+++ b/src/com/android/music/MediaPlaybackService.java
@@ -1720,7 +1720,16 @@ public class MediaPlaybackService extends Service {
             views.setOnClickPendingIntent(R.id.pause, pausePendingIntent);
             viewsLarge.setOnClickPendingIntent(R.id.pause, pausePendingIntent);
             status.flags = Notification.FLAG_ONGOING_EVENT;
-            startForeground(PLAYBACKSERVICE_STATUS, status);
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+
+                startForeground(0, status);
+            }
+
+            else {
+
+              startForeground(1, status);
+            }
 
         }
     }


### PR DESCRIPTION
It seems that settings the `startForeground()` id parameter to `0` fixes crashes on Android Pie and maybe other versions. I don't know how good is this or if there's an alternative, but this seems to work.